### PR TITLE
Implement ALB

### DIFF
--- a/.github/workflows/learn-ecs.yml
+++ b/.github/workflows/learn-ecs.yml
@@ -11,7 +11,6 @@ permissions:
 
 env:
   AWS_REGION: us-east-1 
-  AWS_AZ: us-east-1a
   JENKINS_RUNNER_REPOSITORY: jenkins-runner
   JENKINS_WEB_REPOSITORY: jenkins-web
   ECR_REGISTRY: 286812073492.dkr.ecr.us-east-1.amazonaws.com
@@ -92,7 +91,6 @@ jobs:
         cd terraform 
         terraform plan \
           -var region="${{ env.AWS_REGION }}" \
-          -var availability_zone="${{ env.AWS_AZ }}" \
           -var ecr_registry="${{ env.ECR_REGISTRY }}" \
           -var jenkins_runner_ecr_image="${{ env.JENKINS_RUNNER_REPOSITORY }}" \
           -var jenkins_web_ecr_image="${{ env.JENKINS_WEB_REPOSITORY }}:latest" \
@@ -173,7 +171,6 @@ jobs:
         cd terraform 
         terraform destroy \
           -var region="${{ env.AWS_REGION }}" \
-          -var availability_zone="${{ env.AWS_AZ }}" \
           -var ecr_registry="${{ env.ECR_REGISTRY }}" \
           -var jenkins_runner_ecr_image="${{ env.JENKINS_RUNNER_REPOSITORY }}" \
           -var jenkins_web_ecr_image="${{ env.JENKINS_WEB_REPOSITORY }}:latest" \

--- a/scps/restrict-public-ecs-services.json
+++ b/scps/restrict-public-ecs-services.json
@@ -1,0 +1,20 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Deny",
+        "Action": [
+          "ecs:CreateService",
+          "ecs:UpdateService",
+          "ecs:RegisterTaskDefinition"
+        ],
+        "Resource": "*",
+        "Condition": {
+          "ForAnyValue:StringEquals": {
+            "ecs:AssignPublicIp": "ENABLED"
+          }
+        }
+      }
+    ]
+  }
+  

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,10 +9,10 @@ module "scps" {
 }
 
 module "ecs_network" {
-  source          = "./modules/ecs-network"
-  region          = var.region
-  subnets = var.subnets
-  log_bucket_arn  = module.logging_bucket.bucket_arn
+  source         = "./modules/ecs-network"
+  region         = var.region
+  subnets        = var.subnets
+  log_bucket_arn = module.logging_bucket.bucket_arn
 }
 
 module "ecs_cluster" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,18 +9,20 @@ module "scps" {
 }
 
 module "ecs_network" {
-  source            = "./modules/ecs-network"
-  region            = var.region
-  availability_zone = var.availability_zone
-  log_bucket_arn    = module.logging_bucket.bucket_arn
+  source          = "./modules/ecs-network"
+  region          = var.region
+  subnets = var.subnets
+  log_bucket_arn  = module.logging_bucket.bucket_arn
 }
 
 module "ecs_cluster" {
   depends_on                        = [module.scps]
   source                            = "./modules/ecs-cluster"
   region                            = var.region
-  jenkins_web_subnet_id             = module.ecs_network.web_server_subnet_id
-  jenkins_runner_subnet_id          = module.ecs_network.runner_subnet_id
+  alb_subnet_ids                    = module.ecs_network.public_subnet_ids
+  jenkins_web_subnet_ids            = module.ecs_network.public_subnet_ids
+  jenkins_runner_subnet_ids         = module.ecs_network.private_subnet_ids
+  alb_security_group                = module.ecs_network.alb_security_group
   jenkins_web_security_group        = module.ecs_network.web_server_security_group
   jenkins_runner_security_group     = module.ecs_network.runner_security_group
   jenkins_efs_security_group        = module.ecs_network.efs_security_group

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -20,7 +20,7 @@ module "ecs_cluster" {
   source                            = "./modules/ecs-cluster"
   region                            = var.region
   alb_subnet_ids                    = module.ecs_network.public_subnet_ids
-  jenkins_web_subnet_ids            = module.ecs_network.public_subnet_ids
+  jenkins_web_subnet_ids            = module.ecs_network.private_subnet_ids
   jenkins_runner_subnet_ids         = module.ecs_network.private_subnet_ids
   alb_security_group                = module.ecs_network.alb_security_group
   jenkins_web_security_group        = module.ecs_network.web_server_security_group

--- a/terraform/modules/ecs-cluster/efs.tf
+++ b/terraform/modules/ecs-cluster/efs.tf
@@ -7,8 +7,9 @@ resource "aws_efs_file_system" "jenkins_volume" {
 
 
 resource "aws_efs_mount_target" "jenkins_volume_mount" {
+  count = length(var.jenkins_web_subnet_ids)
   file_system_id  = aws_efs_file_system.jenkins_volume.id
-  subnet_id       = var.jenkins_web_subnet_id
+  subnet_id       = var.jenkins_web_subnet_ids[count.index]
   security_groups = [var.jenkins_efs_security_group]
 }
 

--- a/terraform/modules/ecs-cluster/efs.tf
+++ b/terraform/modules/ecs-cluster/efs.tf
@@ -7,7 +7,7 @@ resource "aws_efs_file_system" "jenkins_volume" {
 
 
 resource "aws_efs_mount_target" "jenkins_volume_mount" {
-  count = length(var.jenkins_web_subnet_ids)
+  count           = length(var.jenkins_web_subnet_ids)
   file_system_id  = aws_efs_file_system.jenkins_volume.id
   subnet_id       = var.jenkins_web_subnet_ids[count.index]
   security_groups = [var.jenkins_efs_security_group]

--- a/terraform/modules/ecs-cluster/iam.tf
+++ b/terraform/modules/ecs-cluster/iam.tf
@@ -96,7 +96,7 @@ resource "aws_iam_policy" "ecs_web_execution_secrets_policy" {
 }
 
 resource "aws_iam_role_policy_attachment" "ecs_web_execution_secrets_policy_attachment" {
-  role = aws_iam_role.ecs_execution_role["web"].name
+  role       = aws_iam_role.ecs_execution_role["web"].name
   policy_arn = aws_iam_policy.ecs_web_execution_secrets_policy.arn
 }
 

--- a/terraform/modules/ecs-cluster/iam.tf
+++ b/terraform/modules/ecs-cluster/iam.tf
@@ -95,8 +95,13 @@ resource "aws_iam_policy" "ecs_web_execution_secrets_policy" {
   })
 }
 
+resource "aws_iam_role_policy_attachment" "ecs_web_execution_secrets_policy_attachment" {
+  role = aws_iam_role.ecs_execution_role["web"].name
+  policy_arn = aws_iam_policy.ecs_web_execution_secrets_policy.arn
+}
+
 resource "aws_iam_role_policy_attachment" "ecs_web_task_secrets_policy_attachment" {
-  role       = aws_iam_role.ecs_execution_role["web"].name
+  role       = aws_iam_role.ecs_task_role["web"].name
   policy_arn = aws_iam_policy.ecs_web_execution_secrets_policy.arn
 }
 

--- a/terraform/modules/ecs-cluster/jenkins-runner/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-runner/main.tf
@@ -88,7 +88,7 @@ resource "aws_ecs_service" "jenkins_runner_service" {
   enable_ecs_managed_tags = true
 
   network_configuration {
-    subnets          = [var.jenkins_runner_subnet_id]
+    subnets          = var.jenkins_runner_subnet_ids
     security_groups  = [var.jenkins_runner_security_group]
   }
 }

--- a/terraform/modules/ecs-cluster/jenkins-runner/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-runner/variables.tf
@@ -1,51 +1,51 @@
 variable "jenkins_cluster_id" {
-    type = string
+  type = string
 }
 
 variable "jenkins_runner_subnet_ids" {
-    type = list(string)
+  type = list(string)
 }
 
 variable "jenkins_runner_security_group" {
-    type = string
+  type = string
 }
 
 variable "jenkins_volume_id" {
-    type = string
+  type = string
 }
 
 variable "jenkins_home_access_point_id" {
-    type = string
+  type = string
 }
 
 variable "jenkins_cert_access_point_id" {
-    type = string
+  type = string
 }
 
 variable "jenkins_master_ip" {
-    type = string
+  type = string
 }
 
 variable "jenkins_agent_secret" {
-    type = string
+  type = string
 }
 
 variable "execution_role_arn" {
-    type = string
+  type = string
 }
 
 variable "task_role_arn" {
-    type = string
+  type = string
 }
 
 variable "deploy_count" {
-    type = number
+  type = number
 }
 
 variable "ecr_registry" {
-    type = string
+  type = string
 }
 
 variable "ecr_image" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-cluster/jenkins-runner/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-runner/variables.tf
@@ -2,8 +2,8 @@ variable "jenkins_cluster_id" {
     type = string
 }
 
-variable "jenkins_runner_subnet_id" {
-    type = string
+variable "jenkins_runner_subnet_ids" {
+    type = list(string)
 }
 
 variable "jenkins_runner_security_group" {

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
@@ -1,26 +1,26 @@
 resource "aws_lb" "jenkins_web_alb" {
-    name = "jenkins-web-alb"
-    internal = false
-    load_balancer_type = "application"
-    security_groups = [var.alb_security_group]
-    subnets = var.alb_subnet_ids 
+  name               = "jenkins-web-alb"
+  internal           = false
+  load_balancer_type = "application"
+  security_groups    = [var.alb_security_group]
+  subnets            = var.alb_subnet_ids
 }
 
 resource "aws_lb_target_group" "jenkins_web_target_group" {
-  name     = "jenkins-web-target-group"
-  port     = 8080
-  protocol = "HTTP"
-  vpc_id   = var.vpc_id
+  name        = "jenkins-web-target-group"
+  port        = 8080
+  protocol    = "HTTP"
+  vpc_id      = var.vpc_id
   target_type = "ip"
 }
 
 resource "aws_lb_listener" "http" {
-    load_balancer_arn = aws_lb.jenkins_web_alb.arn
-    port = "80"
-    protocol = "HTTP"
+  load_balancer_arn = aws_lb.jenkins_web_alb.arn
+  port              = "80"
+  protocol          = "HTTP"
 
-    default_action {
-      type = "forward" 
-      target_group_arn = aws_lb_target_group.jenkins_web_target_group.arn
-    }
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.jenkins_web_target_group.arn
+  }
 }

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
@@ -12,15 +12,6 @@ resource "aws_lb_target_group" "jenkins_web_target_group" {
   protocol = "HTTP"
   vpc_id   = var.vpc_id
   target_type = "ip"
-
-  health_check {
-    path                = "/"
-    interval            = 30
-    timeout             = 10
-    healthy_threshold   = 2
-    unhealthy_threshold = 2
-    matcher             = "200"
-  }
 }
 
 resource "aws_lb_listener" "http" {

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
@@ -1,9 +1,12 @@
+# ALB is intended to be exposed to the internet
+#trivy:ignore:AVD-AWS-0053
 resource "aws_lb" "jenkins_web_alb" {
-  name               = "jenkins-web-alb"
-  internal           = false
-  load_balancer_type = "application"
-  security_groups    = [var.alb_security_group]
-  subnets            = var.alb_subnet_ids
+  name                       = "jenkins-web-alb"
+  internal                   = false
+  load_balancer_type         = "application"
+  security_groups            = [var.alb_security_group]
+  subnets                    = var.alb_subnet_ids
+  drop_invalid_header_fields = true
 }
 
 resource "aws_lb_target_group" "jenkins_web_target_group" {
@@ -14,6 +17,8 @@ resource "aws_lb_target_group" "jenkins_web_target_group" {
   target_type = "ip"
 }
 
+# Partial TLS termination is a future improvement
+#trivy:ignore:AVD-AWS-0054
 resource "aws_lb_listener" "http" {
   load_balancer_arn = aws_lb.jenkins_web_alb.arn
   port              = "80"

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/main.tf
@@ -1,0 +1,35 @@
+resource "aws_lb" "jenkins_web_alb" {
+    name = "jenkins-web-alb"
+    internal = false
+    load_balancer_type = "application"
+    security_groups = [var.alb_security_group]
+    subnets = var.alb_subnet_ids 
+}
+
+resource "aws_lb_target_group" "jenkins_web_target_group" {
+  name     = "jenkins-web-target-group"
+  port     = 8080
+  protocol = "HTTP"
+  vpc_id   = var.vpc_id
+  target_type = "ip"
+
+  health_check {
+    path                = "/"
+    interval            = 30
+    timeout             = 10
+    healthy_threshold   = 2
+    unhealthy_threshold = 2
+    matcher             = "200"
+  }
+}
+
+resource "aws_lb_listener" "http" {
+    load_balancer_arn = aws_lb.jenkins_web_alb.arn
+    port = "80"
+    protocol = "HTTP"
+
+    default_action {
+      type = "forward" 
+      target_group_arn = aws_lb_target_group.jenkins_web_target_group.arn
+    }
+}

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
@@ -1,7 +1,7 @@
 output "target_group_arn" {
-    value = aws_lb_target_group.jenkins_web_target_group.arn
+  value = aws_lb_target_group.jenkins_web_target_group.arn
 }
 
 output "jenkins_web_dns" {
-    value = aws_lb.jenkins_web_alb.dns_name
+  value = aws_lb.jenkins_web_alb.dns_name
 }

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
@@ -1,0 +1,3 @@
+output "target_group_arn" {
+    value = aws_lb_target_group.jenkins_web_target_group.arn
+}

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/outputs.tf
@@ -1,3 +1,7 @@
 output "target_group_arn" {
     value = aws_lb_target_group.jenkins_web_target_group.arn
 }
+
+output "jenkins_web_dns" {
+    value = aws_lb.jenkins_web_alb.dns_name
+}

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/variables.tf
@@ -1,0 +1,11 @@
+variable "alb_security_group" {
+    type = string
+}
+
+variable "alb_subnet_ids" {
+    type = list(string)
+}
+
+variable "vpc_id" {
+    type = string
+}

--- a/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/load-balancer/variables.tf
@@ -1,11 +1,11 @@
 variable "alb_security_group" {
-    type = string
+  type = string
 }
 
 variable "alb_subnet_ids" {
-    type = list(string)
+  type = list(string)
 }
 
 variable "vpc_id" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
@@ -97,6 +97,7 @@ resource "aws_ecs_service" "jenkins_web_service" {
   name            = "jenkins_web_service"
   cluster         = var.jenkins_cluster_id
   task_definition = aws_ecs_task_definition.jenkins_web_task.arn
+  health_check_grace_period_seconds = 600
   desired_count   = 1
   deployment_maximum_percent = 100
   deployment_minimum_healthy_percent = 0

--- a/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
@@ -114,7 +114,6 @@ resource "aws_ecs_service" "jenkins_web_service" {
   network_configuration {
     subnets          = var.jenkins_web_subnet_ids
     security_groups  = [var.jenkins_web_security_group]
-    assign_public_ip = true
   }
 }
 

--- a/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/main.tf
@@ -5,17 +5,17 @@
 # }
 
 module "load_balancer" {
-  source = "./load-balancer"
+  source             = "./load-balancer"
   alb_security_group = var.alb_security_group
-  alb_subnet_ids = var.alb_subnet_ids
-  vpc_id = var.jenkins_vpc_id
+  alb_subnet_ids     = var.alb_subnet_ids
+  vpc_id             = var.jenkins_vpc_id
 }
 
 resource "aws_ecs_task_definition" "jenkins_web_task" {
   family                   = "jenkins-web-task"
   network_mode             = "awsvpc" # Required for Fargate
-  cpu                      = "1024"    # 1 vCPU
-  memory                   = "2048"    # 2 MiB
+  cpu                      = "1024"   # 1 vCPU
+  memory                   = "2048"   # 2 MiB
   requires_compatibilities = ["FARGATE"]
   execution_role_arn       = var.execution_role_arn
   task_role_arn            = var.task_role_arn
@@ -30,7 +30,7 @@ resource "aws_ecs_task_definition" "jenkins_web_task" {
       hostPort      = 8080
       protocol      = "tcp"
       appProtocol   = "http"
-    }, {
+      }, {
       name          = "jnlp"
       containerPort = 50000
       hostPort      = 50000
@@ -39,10 +39,10 @@ resource "aws_ecs_task_definition" "jenkins_web_task" {
     environment = [{
       name  = "JENKINS_ADMIN_ID"
       value = var.jenkins_admin_username
-    },
-    {
-      name  = "JAVA_OPTS"
-      value = "-Djenkins.install.runSetupWizard=false"
+      },
+      {
+        name  = "JAVA_OPTS"
+        value = "-Djenkins.install.runSetupWizard=false"
     }]
     secrets = [
       {
@@ -59,7 +59,7 @@ resource "aws_ecs_task_definition" "jenkins_web_task" {
       }, {
       sourceVolume  = "jenkins_certs"
       containerPath = "/certs/client"
-      }],
+    }],
     # logConfiguration = {
     #     logDriver = "awslogs"
     #     options = {
@@ -94,26 +94,26 @@ resource "aws_ecs_task_definition" "jenkins_web_task" {
 }
 
 resource "aws_ecs_service" "jenkins_web_service" {
-  name            = "jenkins_web_service"
-  cluster         = var.jenkins_cluster_id
-  task_definition = aws_ecs_task_definition.jenkins_web_task.arn
-  health_check_grace_period_seconds = 600
-  desired_count   = 1
-  deployment_maximum_percent = 100
+  name                               = "jenkins_web_service"
+  cluster                            = var.jenkins_cluster_id
+  task_definition                    = aws_ecs_task_definition.jenkins_web_task.arn
+  health_check_grace_period_seconds  = 600
+  desired_count                      = 1
+  deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
-  launch_type     = "FARGATE" # Specifies Fargate
-  enable_execute_command = true
-  enable_ecs_managed_tags = true
+  launch_type                        = "FARGATE" # Specifies Fargate
+  enable_execute_command             = true
+  enable_ecs_managed_tags            = true
 
   load_balancer {
     target_group_arn = module.load_balancer.target_group_arn
-    container_name = "jenkins_web"
-    container_port = 8080
+    container_name   = "jenkins_web"
+    container_port   = 8080
   }
 
   network_configuration {
-    subnets          = var.jenkins_web_subnet_ids
-    security_groups  = [var.jenkins_web_security_group]
+    subnets         = var.jenkins_web_subnet_ids
+    security_groups = [var.jenkins_web_security_group]
   }
 }
 

--- a/terraform/modules/ecs-cluster/jenkins-web-server/outputs.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/outputs.tf
@@ -2,8 +2,23 @@ output "task_arn" {
   value = aws_ecs_task_definition.jenkins_web_task.arn
 }
 
-output "jenkins_web_public_ip" {
-    value = data.aws_network_interface.interface_tags.association[0].public_ip
+output "jenkins_web_dns" {
+  value = module.load_balancer.jenkins_web_dns
+}
+
+resource "null_resource" "wait_for_task_and_fetch_eni" {
+  depends_on = [ aws_ecs_service.jenkins_web_service ]
+  provisioner "local-exec" {
+    command = "aws ecs wait services-stable --cluster ${var.jenkins_cluster_id} --services ${aws_ecs_service.jenkins_web_service.name} --region ${var.region}"
+  }
+}
+
+data "aws_network_interface" "interface_tags" {
+  depends_on = [ null_resource.wait_for_task_and_fetch_eni]
+  filter {
+    name   = "tag:aws:ecs:serviceName"
+    values = [aws_ecs_service.jenkins_web_service.name]
+  }
 }
 
 output "jenkins_web_private_ip" {

--- a/terraform/modules/ecs-cluster/jenkins-web-server/outputs.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/outputs.tf
@@ -7,14 +7,14 @@ output "jenkins_web_dns" {
 }
 
 resource "null_resource" "wait_for_task_and_fetch_eni" {
-  depends_on = [ aws_ecs_service.jenkins_web_service ]
+  depends_on = [aws_ecs_service.jenkins_web_service]
   provisioner "local-exec" {
     command = "aws ecs wait services-stable --cluster ${var.jenkins_cluster_id} --services ${aws_ecs_service.jenkins_web_service.name} --region ${var.region}"
   }
 }
 
 data "aws_network_interface" "interface_tags" {
-  depends_on = [ null_resource.wait_for_task_and_fetch_eni]
+  depends_on = [null_resource.wait_for_task_and_fetch_eni]
   filter {
     name   = "tag:aws:ecs:serviceName"
     values = [aws_ecs_service.jenkins_web_service.name]

--- a/terraform/modules/ecs-cluster/jenkins-web-server/provisioners.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/provisioners.tf
@@ -1,8 +1,8 @@
 resource "null_resource" "jenkins_agent_node" {
-  depends_on = [ module.load_balancer, null_resource.wait_for_task_and_fetch_eni ]
+  depends_on = [module.load_balancer, null_resource.wait_for_task_and_fetch_eni]
   # This will make sure the resource is recreated if the Jenkins URL changes
   triggers = {
-    jenkins_url = "http://${module.load_balancer.jenkins_web_dns}"
+    jenkins_url  = "http://${module.load_balancer.jenkins_web_dns}"
     runner_count = var.jenkins_runner_count
   }
 
@@ -68,8 +68,8 @@ resource "null_resource" "jenkins_agent_node" {
 }
 
 data "local_file" "jenkins_output" {
-  depends_on = [ null_resource.jenkins_agent_node ]
-  filename = "/tmp/jenkins_output.txt"
+  depends_on = [null_resource.jenkins_agent_node]
+  filename   = "/tmp/jenkins_output.txt"
 }
 
 output "agent_secret" {

--- a/terraform/modules/ecs-cluster/jenkins-web-server/provisioners.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/provisioners.tf
@@ -1,33 +1,27 @@
-# Run a local command to wait for the ECS task and fetch the ENI
-resource "null_resource" "wait_for_task_and_fetch_eni" {
-  depends_on = [ aws_ecs_service.jenkins_web_service ]
-  provisioner "local-exec" {
-    command = "aws ecs wait services-stable --cluster ${var.jenkins_cluster_id} --services ${aws_ecs_service.jenkins_web_service.name} --region ${var.region}"
-  }
-}
-
-data "aws_network_interface" "interface_tags" {
-  depends_on = [ null_resource.wait_for_task_and_fetch_eni]
-  filter {
-    name   = "tag:aws:ecs:serviceName"
-    values = [aws_ecs_service.jenkins_web_service.name]
-  }
-}
-
-
 resource "null_resource" "jenkins_agent_node" {
-  depends_on = [ null_resource.wait_for_task_and_fetch_eni ]
+  depends_on = [ module.load_balancer, null_resource.wait_for_task_and_fetch_eni ]
   # This will make sure the resource is recreated if the Jenkins URL changes
   triggers = {
-    jenkins_url = "http://${data.aws_network_interface.interface_tags.association[0].public_ip}:8080"
+    jenkins_url = "http://${module.load_balancer.jenkins_web_dns}"
     runner_count = var.jenkins_runner_count
   }
 
   provisioner "local-exec" {
     command = <<EOF
       # Wait for Jenkins to be up
-      until curl -s -o /dev/null -w "%%{http_code}" ${self.triggers.jenkins_url} | grep -q "403\|200"; do
-        echo "Waiting for Jenkins to be up..."
+      while true; do
+        # Get status code from the curl command
+        status_code=$(curl -s -o /dev/null -w "%%{http_code}" ${self.triggers.jenkins_url})
+
+        if [ "$status_code" = "200" ] || [ "$status_code" = "403" ]; then
+          echo "Jenkins is up with status code $status_code."
+          break
+        elif [ "$status_code" = "503" ]; then
+          echo "Service unavailable (503), continuing to wait..."
+        else
+          echo "Unexpected status code: $status_code, continuing to wait..."
+        fi
+
         sleep 10
       done
 

--- a/terraform/modules/ecs-cluster/jenkins-web-server/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/variables.tf
@@ -2,6 +2,10 @@ variable "region" {
   type = string
 }
 
+variable "jenkins_vpc_id" {
+  type = string
+}
+
 variable "ecr_registry" {
   type = string
 }
@@ -10,7 +14,15 @@ variable "jenkins_web_ecr_image" {
   type = string
 }
 
-variable "jenkins_web_subnet_id" {
+variable "jenkins_web_subnet_ids" {
+  type = list(string)
+}
+
+variable "alb_subnet_ids" {
+  type = list(string)
+}
+
+variable "alb_security_group" {
   type = string
 }
 

--- a/terraform/modules/ecs-cluster/jenkins-web-server/variables.tf
+++ b/terraform/modules/ecs-cluster/jenkins-web-server/variables.tf
@@ -64,9 +64,9 @@ variable "jenkins_admin_password_arn" {
 }
 
 variable "execution_role_arn" {
-    type = string
+  type = string
 }
 
 variable "task_role_arn" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-cluster/main.tf
+++ b/terraform/modules/ecs-cluster/main.tf
@@ -17,9 +17,12 @@ resource "aws_ecs_cluster" "jenkins_cluster" {
 module "jenkins_web_server" {
   source                       = "./jenkins-web-server"
   region                       = var.region
+  jenkins_vpc_id               = var.jenkins_vpc_id
   ecr_registry                 = var.ecr_registry
   jenkins_web_ecr_image        = var.jenkins_web_ecr_image
-  jenkins_web_subnet_id        = var.jenkins_web_subnet_id
+  alb_subnet_ids               = var.alb_subnet_ids
+  jenkins_web_subnet_ids       = var.jenkins_web_subnet_ids
+  alb_security_group           = var.alb_security_group
   jenkins_web_security_group   = var.jenkins_web_security_group
   jenkins_volume_id            = aws_efs_file_system.jenkins_volume.id
   jenkins_home_access_point_id = aws_efs_access_point.jenkins_home.id
@@ -37,7 +40,7 @@ module "jenkins_runner" {
   source                        = "./jenkins-runner"
   ecr_registry                  = var.ecr_registry
   ecr_image                     = var.jenkins_runner_ecr_image
-  jenkins_runner_subnet_id      = var.jenkins_runner_subnet_id
+  jenkins_runner_subnet_ids     = var.jenkins_runner_subnet_ids
   jenkins_runner_security_group = var.jenkins_runner_security_group
   jenkins_volume_id             = aws_efs_file_system.jenkins_volume.id
   jenkins_home_access_point_id  = aws_efs_access_point.jenkins_home.id

--- a/terraform/modules/ecs-cluster/outputs.tf
+++ b/terraform/modules/ecs-cluster/outputs.tf
@@ -1,5 +1,5 @@
-output "jenkins_web_public_ip" {
-  value = module.jenkins_web_server.jenkins_web_public_ip
+output "jenkins_web_dns" {
+  value = module.jenkins_web_server.jenkins_web_dns
 }
 
 output "agent_secret" {

--- a/terraform/modules/ecs-cluster/variables.tf
+++ b/terraform/modules/ecs-cluster/variables.tf
@@ -1,11 +1,20 @@
 variable "region" {
   type = string
 }
-variable "jenkins_web_subnet_id" {
-  type = string
+
+variable "alb_subnet_ids" {
+  type = list(string)
 }
 
-variable "jenkins_runner_subnet_id" {
+variable "jenkins_web_subnet_ids" {
+  type = list(string)
+}
+
+variable "jenkins_runner_subnet_ids" {
+  type = list(string)
+}
+
+variable "alb_security_group" {
   type = string
 }
 

--- a/terraform/modules/ecs-network/efs/outputs.tf
+++ b/terraform/modules/ecs-network/efs/outputs.tf
@@ -1,3 +1,3 @@
 output "security_group_id" {
-    value = aws_security_group.efs_sg.id
+  value = aws_security_group.efs_sg.id
 }

--- a/terraform/modules/ecs-network/efs/variables.tf
+++ b/terraform/modules/ecs-network/efs/variables.tf
@@ -1,11 +1,11 @@
 variable "vpc_id" {
-    type = string
+  type = string
 }
 
 variable "web_server_security_group_id" {
-    type = string
+  type = string
 }
 
 variable "runner_security_group_id" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-network/jenkins-runner/main.tf
+++ b/terraform/modules/ecs-network/jenkins-runner/main.tf
@@ -13,5 +13,5 @@ resource "aws_security_group" "runner_sg" {
 resource "aws_vpc_security_group_egress_rule" "allow_runner_all_outbound" {
   security_group_id = aws_security_group.runner_sg.id
   cidr_ipv4         = "0.0.0.0/0"
-  ip_protocol = "-1" # semantically equivalent to all ports
+  ip_protocol       = "-1" # semantically equivalent to all ports
 }

--- a/terraform/modules/ecs-network/jenkins-runner/outputs.tf
+++ b/terraform/modules/ecs-network/jenkins-runner/outputs.tf
@@ -1,3 +1,3 @@
 output "security_group_id" {
-    value = aws_security_group.runner_sg.id
+  value = aws_security_group.runner_sg.id
 }

--- a/terraform/modules/ecs-network/jenkins-runner/variables.tf
+++ b/terraform/modules/ecs-network/jenkins-runner/variables.tf
@@ -1,3 +1,3 @@
 variable "vpc_id" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-network/jenkins-web-server/main.tf
+++ b/terraform/modules/ecs-network/jenkins-web-server/main.tf
@@ -8,21 +8,9 @@ resource "aws_security_group" "web_server_sg" {
   }
 }
 
-# Web server is intended to be used universally
-#trivy:ignore:AVD-AWS-0107
 resource "aws_vpc_security_group_ingress_rule" "allow_web_server_http" {
   security_group_id = aws_security_group.web_server_sg.id
-  cidr_ipv4         = "0.0.0.0/0"
-  from_port         = 8080
-  ip_protocol       = "tcp"
-  to_port           = 8080
-}
-
-# Web server is intended to be used universally
-#trivy:ignore:AVD-AWS-0107
-resource "aws_vpc_security_group_ingress_rule" "allow_web_server_http_ipv6" {
-  security_group_id = aws_security_group.web_server_sg.id
-  cidr_ipv6         = "::/0"
+  referenced_security_group_id = var.alb_security_group
   from_port         = 8080
   ip_protocol       = "tcp"
   to_port           = 8080

--- a/terraform/modules/ecs-network/jenkins-web-server/main.tf
+++ b/terraform/modules/ecs-network/jenkins-web-server/main.tf
@@ -8,12 +8,20 @@ resource "aws_security_group" "web_server_sg" {
   }
 }
 
-resource "aws_vpc_security_group_ingress_rule" "allow_web_server_http" {
-  security_group_id = aws_security_group.web_server_sg.id
+resource "aws_vpc_security_group_ingress_rule" "allow_alb_http" {
+  security_group_id            = aws_security_group.web_server_sg.id
   referenced_security_group_id = var.alb_security_group
-  from_port         = 8080
-  ip_protocol       = "tcp"
-  to_port           = 8080
+  from_port                    = 8080
+  ip_protocol                  = "tcp"
+  to_port                      = 8080
+}
+
+resource "aws_vpc_security_group_ingress_rule" "allow_runner_http" {
+  security_group_id            = aws_security_group.web_server_sg.id
+  referenced_security_group_id = var.runner_sg
+  from_port                    = 8080
+  ip_protocol                  = "tcp"
+  to_port                      = 8080
 }
 
 resource "aws_vpc_security_group_ingress_rule" "allow_efs_from_ecs" {

--- a/terraform/modules/ecs-network/jenkins-web-server/outputs.tf
+++ b/terraform/modules/ecs-network/jenkins-web-server/outputs.tf
@@ -1,3 +1,3 @@
 output "security_group_id" {
-    value = aws_security_group.web_server_sg.id
+  value = aws_security_group.web_server_sg.id
 }

--- a/terraform/modules/ecs-network/jenkins-web-server/variables.tf
+++ b/terraform/modules/ecs-network/jenkins-web-server/variables.tf
@@ -5,3 +5,7 @@ variable "vpc_id" {
 variable "runner_sg" {
     type = string
 }
+
+variable "alb_security_group" {
+    type = string
+}

--- a/terraform/modules/ecs-network/jenkins-web-server/variables.tf
+++ b/terraform/modules/ecs-network/jenkins-web-server/variables.tf
@@ -1,11 +1,11 @@
 variable "vpc_id" {
-    type = string
+  type = string
 }
 
 variable "runner_sg" {
-    type = string
+  type = string
 }
 
 variable "alb_security_group" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-network/load-balancer/main.tf
+++ b/terraform/modules/ecs-network/load-balancer/main.tf
@@ -1,0 +1,37 @@
+resource "aws_security_group" "alb_security_group" {
+  name        = "alb_security_group"
+  description = "Rules for the ALB security group"
+  vpc_id      = var.vpc_id
+
+  tags = {
+    Name = "alb_sg"
+  }
+}
+
+# ALB is intended to be used universally
+#trivy:ignore:AVD-AWS-0107
+resource "aws_vpc_security_group_ingress_rule" "allow_alb_http" {
+  security_group_id = aws_security_group.alb_security_group.id
+  cidr_ipv4         = "0.0.0.0/0"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+# Web server is intended to be used universally
+#trivy:ignore:AVD-AWS-0107
+resource "aws_vpc_security_group_ingress_rule" "allow_alb_http_ipv6" {
+  security_group_id = aws_security_group.alb_security_group.id
+  cidr_ipv6         = "::/0"
+  from_port         = 80
+  ip_protocol       = "tcp"
+  to_port           = 80
+}
+
+# Web server is intended to be used universally
+#trivy:ignore:AVD-AWS-0104
+resource "aws_vpc_security_group_egress_rule" "allow_alb_all_outbound" {
+  security_group_id = aws_security_group.alb_security_group.id
+  cidr_ipv4         = "0.0.0.0/0"
+  ip_protocol       = "-1" # semantically equivalent to all ports
+}

--- a/terraform/modules/ecs-network/load-balancer/outputs.tf
+++ b/terraform/modules/ecs-network/load-balancer/outputs.tf
@@ -1,0 +1,3 @@
+output "alb_security_group" {
+    value = aws_security_group.alb_security_group.id
+}

--- a/terraform/modules/ecs-network/load-balancer/outputs.tf
+++ b/terraform/modules/ecs-network/load-balancer/outputs.tf
@@ -1,3 +1,3 @@
 output "alb_security_group" {
-    value = aws_security_group.alb_security_group.id
+  value = aws_security_group.alb_security_group.id
 }

--- a/terraform/modules/ecs-network/load-balancer/variables.tf
+++ b/terraform/modules/ecs-network/load-balancer/variables.tf
@@ -1,0 +1,3 @@
+variable "vpc_id" {
+    type = string
+}

--- a/terraform/modules/ecs-network/load-balancer/variables.tf
+++ b/terraform/modules/ecs-network/load-balancer/variables.tf
@@ -1,3 +1,3 @@
 variable "vpc_id" {
-    type = string
+  type = string
 }

--- a/terraform/modules/ecs-network/main.tf
+++ b/terraform/modules/ecs-network/main.tf
@@ -140,6 +140,7 @@ module "jenkins_web_server_network" {
   source    = "./jenkins-web-server"
   vpc_id    = aws_vpc.ecs_vpc.id
   runner_sg = module.jenkins_runner_network.security_group_id
+  alb_security_group = module.alb_network.alb_security_group
 }
 
 module "efs_network" {

--- a/terraform/modules/ecs-network/main.tf
+++ b/terraform/modules/ecs-network/main.tf
@@ -137,9 +137,9 @@ module "alb_network" {
 }
 
 module "jenkins_web_server_network" {
-  source    = "./jenkins-web-server"
-  vpc_id    = aws_vpc.ecs_vpc.id
-  runner_sg = module.jenkins_runner_network.security_group_id
+  source             = "./jenkins-web-server"
+  vpc_id             = aws_vpc.ecs_vpc.id
+  runner_sg          = module.jenkins_runner_network.security_group_id
   alb_security_group = module.alb_network.alb_security_group
 }
 

--- a/terraform/modules/ecs-network/outputs.tf
+++ b/terraform/modules/ecs-network/outputs.tf
@@ -1,9 +1,13 @@
-output "web_server_subnet_id" {
-  value = aws_subnet.ecs_vpc_public_subnet.id
+output "public_subnet_ids" {
+  value = [for subnet in aws_subnet.ecs_vpc_public_subnets : subnet.id]
 }
 
-output "runner_subnet_id" {
-  value = aws_subnet.ecs_vpc_private_subnet.id
+output "private_subnet_ids" {
+  value = [for subnet in aws_subnet.ecs_vpc_private_subnets : subnet.id]
+}
+
+output "alb_security_group" {
+  value = module.alb_network.alb_security_group
 }
 
 output "web_server_security_group" {

--- a/terraform/modules/ecs-network/variables.tf
+++ b/terraform/modules/ecs-network/variables.tf
@@ -4,10 +4,10 @@ variable "region" {
 
 variable "subnets" {
   type = list(object({
-    name       = string
-    public_cidr_block = string
+    name               = string
+    public_cidr_block  = string
     private_cidr_block = string
-    az         = string
+    az                 = string
   }))
 }
 

--- a/terraform/modules/ecs-network/variables.tf
+++ b/terraform/modules/ecs-network/variables.tf
@@ -2,8 +2,13 @@ variable "region" {
   type = string
 }
 
-variable "availability_zone" {
-  type = string
+variable "subnets" {
+  type = list(object({
+    name       = string
+    public_cidr_block = string
+    private_cidr_block = string
+    az         = string
+  }))
 }
 
 variable "log_bucket_arn" {

--- a/terraform/modules/scps/main.tf
+++ b/terraform/modules/scps/main.tf
@@ -42,3 +42,14 @@ resource "aws_organizations_policy_attachment" "restrict_image_source_scp_attach
   target_id = data.aws_caller_identity.current.id
 }
 
+# Restrict public IP addresses on ECS resources
+resource "aws_organizations_policy" "restrict_public_ecs_services" {
+  name        = "RestrictPublicECS"
+  description = "Prevents ECS services from being created with a public IP"
+  content     = file("${path.module}/../../../scps/restrict-public-ecs-services.json")
+  type        = "SERVICE_CONTROL_POLICY"
+}
+resource "aws_organizations_policy_attachment" "restrict_public_ecs_services_attachment" {
+  policy_id = aws_organizations_policy.restrict_public_ecs_services.id
+  target_id = data.aws_organizations_organization.my_org.roots[0].id
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
-output "jenkins_web_public_ip" {
-  value = module.ecs_cluster.jenkins_web_public_ip
+output "jenkins_web_dns" {
+  value = module.ecs_cluster.jenkins_web_dns
 }
 
 output "agent_secret" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -3,9 +3,25 @@ variable "region" {
   default = "us-east-1"
 }
 
-variable "availability_zone" {
-  type    = string
-  default = "us-east-1a"
+variable "subnets" {
+  type = list(object({
+    name       = string
+    public_cidr_block = string
+    private_cidr_block = string
+    az         = string
+  }))
+
+  default = [{
+    az         = "us-east-1a"
+    public_cidr_block = "10.0.1.0/24"
+    private_cidr_block = "10.0.3.0/24"
+    name       = "subnet_a"
+    }, {
+    az         = "us-east-1b"
+    public_cidr_block = "10.0.2.0/24"
+    private_cidr_block = "10.0.4.0/24"
+    name       = "subnet_b"
+  }]
 }
 
 variable "ecr_registry" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -5,22 +5,22 @@ variable "region" {
 
 variable "subnets" {
   type = list(object({
-    name       = string
-    public_cidr_block = string
+    name               = string
+    public_cidr_block  = string
     private_cidr_block = string
-    az         = string
+    az                 = string
   }))
 
   default = [{
-    az         = "us-east-1a"
-    public_cidr_block = "10.0.1.0/24"
+    az                 = "us-east-1a"
+    public_cidr_block  = "10.0.1.0/24"
     private_cidr_block = "10.0.3.0/24"
-    name       = "subnet_a"
+    name               = "subnet_a"
     }, {
-    az         = "us-east-1b"
-    public_cidr_block = "10.0.2.0/24"
+    az                 = "us-east-1b"
+    public_cidr_block  = "10.0.2.0/24"
     private_cidr_block = "10.0.4.0/24"
-    name       = "subnet_b"
+    name               = "subnet_b"
   }]
 }
 


### PR DESCRIPTION
- Adds an ALB in front of the Jenkins web server
- Moves the Jenkins web server to the private subnet and removes public IP assignment
- Limit web server security groups to runner and ALB
- Creates an SCP to prevent the use of public IPs for ECS services
- Outputs ALB DNS name instead of IP address